### PR TITLE
fix: don't ignore loopback-free value

### DIFF
--- a/mount_btrfs.sh
+++ b/mount_btrfs.sh
@@ -10,12 +10,12 @@ BTRFS_TARGET_DIR="${BTRFS_TARGET_DIR:-$(
 # Options used to mount
 BTRFS_MOUNT_OPTS=${BTRFS_MOUNT_OPTS:-"compress-force=zstd:2"}
 # Location where the loopback file will be placed.
-_BTRFS_LOOPBACK_FILE=${_BTRFS_LOOPBACK_FILE:-/mnt/btrfs_loopbacks/$(systemd-escape -p "$BTRFS_TARGET_DIR")}
+BTRFS_LOOPBACK_FILE=${BTRFS_LOOPBACK_FILE:-/mnt/btrfs_loopbacks/$(systemd-escape -p "$BTRFS_TARGET_DIR")}
 # Percentage of the total space to use. Max: 1.0, Min: 0.0
-BTRFS_LOOPBACK_FREE=${_BTRFS_LOOPBACK_FREE:-"0.8"}
+BTRFS_LOOPBACK_FREE=${BTRFS_LOOPBACK_FREE:-"0.8"}
 
 # Result of $(dirname "$_BTRFS_LOOPBACK_FILE")
-btrfs_pdir="$(dirname "$_BTRFS_LOOPBACK_FILE")"
+btrfs_pdir="$(dirname "$BTRFS_LOOPBACK_FILE")"
 
 # Install btrfs-progs
 sudo apt-get install -y btrfs-progs
@@ -51,17 +51,17 @@ _final_size=$(
         jq -r --arg freeperc "$BTRFS_LOOPBACK_FREE" \
             '.filesystems[0].avail * ($freeperc | tonumber) | round'
 )
-truncate -s "$_final_size" "$_BTRFS_LOOPBACK_FILE"
+truncate -s "$_final_size" "$BTRFS_LOOPBACK_FILE"
 unset -v _final_size
 
 # # Stop docker services
 # sudo systemctl stop docker
 
 # Format btrfs loopback
-sudo mkfs.btrfs -f -r "$BTRFS_TARGET_DIR" "$_BTRFS_LOOPBACK_FILE"
+sudo mkfs.btrfs -f -r "$BTRFS_TARGET_DIR" "$BTRFS_LOOPBACK_FILE"
 
 # Mount
-sudo systemd-mount "$_BTRFS_LOOPBACK_FILE" "$BTRFS_TARGET_DIR" \
+sudo systemd-mount "$BTRFS_LOOPBACK_FILE" "$BTRFS_TARGET_DIR" \
     ${BTRFS_MOUNT_OPTS:+ --options="${BTRFS_MOUNT_OPTS}"}
 
 # # Restart docker services


### PR DESCRIPTION
demonstrated that this work here
https://github.com/renner0e/diffuse/actions/runs/16627555396/job/47048107481
`    1     6.55GiB  /mnt/btrfs_loopbacks/var-lib-containers`

this removes the leading underscore, which causes the variable to be passed properly and now won't always use 80% as the size of `/mnt`

bluefin sets this [here](https://github.com/ublue-os/bluefin/blob/main/.github/workflows/reusable-build.yml#L50) and it is the same size as it would be for 0.8