### PR TITLE
chore: remove the retry logic

### DIFF
--- a/mount_btrfs.sh
+++ b/mount_btrfs.sh
@@ -20,29 +20,20 @@ btrfs_pdir="$(dirname "$BTRFS_LOOPBACK_FILE")"
 # Install btrfs-progs
 sudo apt-get install -y btrfs-progs
 
-# use 60 GB to determine if Github mounted /mnt already
+# use 60 GB to determine if Github allocated space for /mnt
 # It should have 66GB avail out of 74GB
 MIN_SPACE=$((60 * 1000 * 1000 * 1000))
-MAX_RETRIES=3
 
-for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
-  AVAILABLE=$(findmnt /mnt --bytes --df --json | jq -r '.filesystems[0].avail')
-  AVAILABLE_HUMAN=$(findmnt /mnt --df --json | jq -r '.filesystems[0].avail')
+AVAILABLE=$(findmnt /mnt --bytes --df --json | jq -r '.filesystems[0].avail')
+AVAILABLE_HUMAN=$(findmnt /mnt --df --json | jq -r '.filesystems[0].avail')
 
-  if [[ "$AVAILABLE" -ge "$MIN_SPACE" ]]; then
-    echo "Enough space available: $AVAILABLE_HUMAN"
-    break  # Exit the loop if enough space is available
-  else
-    echo "Not enough space, it seems like the runner has not mounted /mnt yet "
-    echo "Available size: $AVAILABLE_HUMAN. Waiting 5 seconds..."
-    sleep 5
-
-    if (( ATTEMPT == MAX_RETRIES )); then
-      echo "Max retries reached. Exiting."
-      exit 1
-    fi
-  fi
-done
+if [[ "$AVAILABLE" -ge "$MIN_SPACE" ]]; then
+  echo "Enough space available: $AVAILABLE_HUMAN"
+else
+  echo "/mnt doesn't have the desired capacity."
+  echo "Available size: $AVAILABLE_HUMAN"
+  echo "This usually happens when many runners are competing for resources"
+fi
 
 # Create loopback file
 sudo mkdir -p "$btrfs_pdir" && sudo chown "$(id -u)":"$(id -g)" "$btrfs_pdir"


### PR DESCRIPTION
This is unnecessary and I was wrong.
I haven't seen a single occurrence so far where /mnt "grows" where this would be needed.