### PR TITLE
fix: add id to check `/mnt` step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Check /mnt mountpoint
+      id: check_mnt
       shell: bash
       run: |
         if sudo mountpoint /mnt >/dev/null 2>&1; then


### PR DESCRIPTION
Should fix the action not doing anything even when /mnt is present.